### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -20,39 +20,23 @@
     }
   },
   "targetDefaults": {
-    "dev": {
-      "dependsOn": ["build"],
-      "configurations": {},
-      "options": {}
-    },
-    "serve": {
-      "dependsOn": ["build"]
-    },
-    "build-inline-fns": {
-      "dependsOn": ["^build"],
-      "outputs": ["{projectRoot}/src"]
-    },
+    "dev": { "dependsOn": ["build"], "configurations": {}, "options": {} },
+    "serve": { "dependsOn": ["build"] },
+    "build-inline-fns": { "dependsOn": ["^build"], "outputs": ["{projectRoot}/src"] },
     "build": {
       "dependsOn": ["^build", "prebuild"],
       "outputs": ["{projectRoot}/dist"],
       "executor": "nx:run-script",
-      "options": {
-        "script": "build"
-      }
+      "options": { "script": "build" }
     },
-    "typecheck": {
-      "dependsOn": ["^build"]
-    },
-    "release": {
-      "dependsOn": ["build"]
-    }
+    "typecheck": { "dependsOn": ["^build"] },
+    "release": { "dependsOn": ["build"] }
   },
-  "affected": {
-    "defaultBase": "main"
-  },
+  "affected": { "defaultBase": "main" },
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "sharedGlobals": [],
     "production": ["default"]
-  }
+  },
+  "nxCloudAccessToken": "M2QzNmJhNTYtZDQ2MC00YTVjLTk2MWItZmNjMTQyMGZjMTc1fHJlYWQtd3JpdGU="
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/675ae5d85185be465bb5fede/workspaces/675ae627057307a72ab3036e

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.